### PR TITLE
Add support for label and name of slave.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ You can specify optional environment variables below when invoking docker run to
 | Parameter       | Default Value       | Description                                                                |
 |-----------------|---------------------|----------------------------------------------------------------------------|
 | SLAVE_EXECUTORS | number of cpu cores | This value specifies the number of concurrent jobs this worker can process |
+| SLAVE_NAME      | swarm-client        | This value specifies the name of slave that will appear on Jenkins UI      |
+| SLAVE_LABELS    | None                | This value specifies the labels you want to give for the launching slave   |

--- a/cmd.sh
+++ b/cmd.sh
@@ -13,6 +13,12 @@ fi
 if [ ! -z "$SLAVE_EXECUTORS" ]; then
   PARAMS="$PARAMS -executors $SLAVE_EXECUTORS"
 fi
+if [ ! -z "$SLAVE_LABELS" ]; then
+  PARAMS="$PARAMS -labels $SLAVE_LABELS"
+fi
+if [ ! -z "$SLAVE_NAME" ]; then
+  PARAMS="$PARAMS -name $SLAVE_NAME"
+fi
 if [ ! -z "$JENKINS_MASTER" ]; then
   PARAMS="$PARAMS -master $JENKINS_MASTER"
 else


### PR DESCRIPTION
We can provide labels and name of slave that we are about
to launch via swarm-client frrom cli. Labels are useful when
you have jobs that run using the node-label parameter and slave
specific jobs.
