### PR TITLE
updates to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,52 @@
 FROM ubuntu:xenial
 
-MAINTAINER Bilal Sheikh <bilal@techtraits.com>
+LABEL "Maintainer Chris Mosetick <cmosetick@gmail.com>"
 
-RUN apt-get update && apt-get -y upgrade && apt-get -y install software-properties-common && add-apt-repository ppa:webupd8team/java -y && apt-get update
+ARG github_token
 
-RUN (echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections) && apt-get install -y oracle-java8-installer oracle-java8-set-default
+RUN \
+sed -i 's@http://archive.ubuntu.com/ubuntu/@http://ubuntu.osuosl.org/ubuntu@g' /etc/apt/sources.list && \
+apt-get update && \
+apt-get -y install software-properties-common wget curl jq git iptables ca-certificates apparmor && \
+add-apt-repository ppa:webupd8team/java -y && \
+apt-get update
+
+RUN \
+(echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections) && \
+apt-get install -y oracle-java8-installer oracle-java8-set-default
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 ENV PATH $JAVA_HOME/bin:$PATH
-
-
-# apparmor is required to run docker server within docker container
-RUN apt-get update -qq && apt-get install -qqy wget curl git iptables ca-certificates apparmor
-
-ENV JENKINS_SWARM_VERSION 2.2
+ENV JENKINS_SWARM_VERSION 3.3
 ENV HOME /home/jenkins-slave
 
 
-RUN useradd -c "Jenkins Slave user" -d $HOME -m jenkins-slave
-RUN curl --create-dirs -sSLo $HOME/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar
-ADD cmd.sh /cmd.sh
-
-# set our wrapper
-ENTRYPOINT ["/usr/local/bin/docker-wrapper"]
+RUN \
+useradd -c "Jenkins Slave user" -d $HOME -m jenkins-slave && \
+curl --create-dirs -sSLo $HOME/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar
+COPY cmd.sh /cmd.sh
 
 # setup our local files first
-ADD docker-wrapper.sh /usr/local/bin/docker-wrapper
+COPY docker-wrapper.sh /usr/local/bin/docker-wrapper
 RUN chmod +x /usr/local/bin/docker-wrapper
+# Always install latest version of Rancher CLI using Github API call in bash script
+# pass in --build-arg github_token=<token> to make the download authenticated
+COPY rancher-cli-download.sh /usr/local/bin/rancher-cli-download.sh
+
 
 # now we install docker in docker - thanks to https://github.com/jpetazzo/dind
 # We install newest docker into our docker in docker container
-RUN curl -fsSLO https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz \
-  && tar --strip-components=1 -xvzf docker-latest.tgz -C /usr/local/bin \
-  && chmod +x /usr/local/bin/docker \
-# install Rancher CLI
-  && curl -fsSLO https://github.com/rancher/cli/releases/download/v0.4.1/rancher-linux-amd64-v0.4.1.tar.gz \
-  && tar --strip-components=2 -xzvf rancher-linux-amd64-v0.4.1.tar.gz -C /usr/local/bin \
-  && chmod +x /usr/local/bin/rancher
+RUN \
+curl -fsSLO https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz && \
+tar --strip-components=1 -xvzf docker-latest.tgz -C /usr/local/bin && \
+chmod +x /usr/local/bin/docker
+
+RUN \
+/usr/local/bin/rancher-cli-download.sh && \
+tar xvf rancher-linux-amd64* && \
+cp rancher-v*/rancher /usr/local/bin && \
+chmod +x /usr/local/bin/rancher && \
+rm -rf /var/cache/apt/*
 
 VOLUME /var/lib/docker
 
@@ -44,4 +54,5 @@ VOLUME /var/lib/docker
 #ENV JENKINS_PASSWORD jenkins
 #ENV JENKINS_MASTER http://jenkins:8080
 
+ENTRYPOINT ["/usr/local/bin/docker-wrapper"]
 CMD /bin/bash /cmd.sh

--- a/rancher-cli-download.sh
+++ b/rancher-cli-download.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+source /.dockerenv
+
+# $github_token set at docker build time via: --build-arg github_token=
+URL=$(curl -H "Authorization: token $github_token" -s https://api.github.com/repos/rancher/cli/releases/latest | jq -r ".assets[] | select(.name | contains(\"linux-amd64\")) | select(.content_type | contains(\"gzip\")) | .browser_download_url")
+
+wget $URL


### PR DESCRIPTION
- overhaul Dockerfile
- always download and install latest version of Rancher CLI via Github API call (bash script)
- If needed for build process, pass in an api token with `docker build --build-arg github_token=<token>`

The idea is to cut down on the amount of work that needs to be done in source control here every time a new version of the Rancher CLI is released. All that needs to happen is a periodic build of this image.

Additionally, the script which calls the Github API is left in the image, so a new version of Rancher CLI could be updated in an existing container if a user wanted too.