### PR TITLE
Fixed: the slave does not start when passing several labels

### DIFF
--- a/cmd.sh
+++ b/cmd.sh
@@ -14,7 +14,9 @@ if [ ! -z "$SLAVE_EXECUTORS" ]; then
   PARAMS="$PARAMS -executors $SLAVE_EXECUTORS"
 fi
 if [ ! -z "$SLAVE_LABELS" ]; then
-  PARAMS="$PARAMS -labels $SLAVE_LABELS"
+  for LABEL in $SLAVE_LABELS; do
+    PARAMS="$PARAMS -labels $LABEL"
+  done
 fi
 if [ ! -z "$SLAVE_NAME" ]; then
   PARAMS="$PARAMS -name $SLAVE_NAME"


### PR DESCRIPTION
I modified `cmd.sh` so that when you set the `SLAVE_LABEL` to a space separated list, it generates multiple `-label ` args : 
`docker run -d -e SLAVE_LABELS="foo bar" jenkins-slave`
-> `java -jar /home/jenkins-slave/swarm-client-2.2-jar-with-dependencies.jar -labels foo -labels bar -fsroot /home/jenkins-slave`

Formerly, it generated a unique `-label foo bar` arg which raised an exception and prevented the slave to start
